### PR TITLE
Fixed negative remaning lock days and wrong apr

### DIFF
--- a/src/hooks/useValidator.ts
+++ b/src/hooks/useValidator.ts
@@ -60,7 +60,7 @@ export default function useValidator(validatorId: bigint): Validator | null {
 		selfStake: selfStake,
 		delegatedStake: validatorInfo[3] - selfStake,
 		lockedSelfStake: lockupInfo[0],
-		remainingLockedStakeDays: Math.floor(dayjs.unix(Number(lockupInfo[2])).diff(dayjs(), 'days')),
+		remainingLockedStakeDays: Math.max(0, Math.floor(dayjs.unix(Number(lockupInfo[2])).diff(dayjs(), 'days'))),
 		socialInfoUrl: socialInfo
 	};
 }


### PR DESCRIPTION
fixes an issue where `remainingLockedStakeDays` could return negative values when the calculated difference between lockup end time and current time was negative